### PR TITLE
Make Croppr handle resized large images

### DIFF
--- a/modules/services/crop.js
+++ b/modules/services/crop.js
@@ -82,6 +82,7 @@ export default scope => {
 										allImages[i].style.height = previewWindow.offsetHeight + "px";
 									}
 								}
+								instance.reset();
 							}
 						});
 						const cropperDiv = scope.modalElement.querySelector("#imageCropper");


### PR DESCRIPTION
Call Croppr.reset() after editing the image height in order to correctly position the cropping bounding box.

When the image uploaded is large, Uppload will resize it to fit within the modal, but this results in Croppr positioning the cropping bounding box incorrectly.