### PR TITLE
Show error on top of image, rather than behind it

### DIFF
--- a/styles/services.scss
+++ b/styles/services.scss
@@ -93,6 +93,7 @@
 		top: 0;
 		opacity: 0;
 		transition: 0.5s;
+		z-index: 10;
 		&.visible {
 			opacity: 1;
 		}


### PR DESCRIPTION
In Chrome, the error message will show behind the image if the image is portrait. Adding the z-index resolves the issue.