### PR TITLE
allow switching devices when available

### DIFF
--- a/modules/icons.js
+++ b/modules/icons.js
@@ -9,5 +9,6 @@ export default {
 	uploading: `<i class="fas fa-spinner fa-4x fa-spin fa-fw"></i><br><br>`,
 	uploaded: `<i class="fas fa-check-circle fa-4x fa-fw"></i><br><br>`,
 	error: `<i class="fas fa-exclamation-triangle fa-4x fa-fw"></i><br><br>`,
-	file: `<i class="fas fa-file fa-fw"></i>`
+	file: `<i class="fas fa-file fa-fw"></i>`,
+	switchDevice: `<i class="fas fa-sync fa-fw"></i>`,
 };

--- a/modules/services.js
+++ b/modules/services.js
@@ -96,7 +96,10 @@ export default scope => {
 						<canvas id="cameraCanvas"></canvas>
 					</div>
 					<div class="bottom-buttons">
-						<div class="cta"><button class="primary-button" id="clickButton">${icons.camera} &nbsp;${i18n.camera.click}</button></div>
+						<div class="cta">
+                            <button class="primary-button secondary" id="switchDeviceButton" style="display: none;">${icons.switchDevice}</button>
+                            <button class="primary-button" id="clickButton">${icons.camera} &nbsp;${i18n.camera.click}</button>
+                        </div>
 					</div>
 				</div>
 			`,


### PR DESCRIPTION
This adds a button to the camera service to allow cycling through the available video devices, usually front and rear cameras on mobile. If there is only one device, the button will not be shown.