### PR TITLE
Make sure the camera closes properly when Uppload is closed

### DIFF
--- a/src/uppload.ts
+++ b/src/uppload.ts
@@ -841,6 +841,7 @@ export class Uppload implements IUppload {
     if (currentService.length) {
       const service = currentService[0];
       service.stop();
+      this.activeService = "default";
     }
   }
 

--- a/src/uppload.ts
+++ b/src/uppload.ts
@@ -841,7 +841,7 @@ export class Uppload implements IUppload {
     if (currentService.length) {
       const service = currentService[0];
       service.stop();
-      this.activeService = "default";
+      this.activeService = this.services[0].name;
     }
   }
 


### PR DESCRIPTION
This is a solution to #165 that works for me. Let me know what you think!

As @AnandChowdhary says - the `close()` function is correctly called on the currently active service when the user switches to a new service or closes the modal.

The problem is that *after* this happens, the active service is restarted by the call to `update()` at the end of the `Uppload#close()`. By setting the active service back to 'default' at the end of the cleanup function for the current service, we stop the camera from being *re*opened after the modal is closed.

This will hopefully have some knock-on benefits for the other plugins too if they're expected to clean up resources when they shut down.

Does this sound right to you? I'm no TS expert so apologies if I haven't changed some things I should have changed.