### PR TITLE
fixed empty uppload-container on creation

### DIFF
--- a/src/uppload.ts
+++ b/src/uppload.ts
@@ -61,14 +61,13 @@ export class Uppload implements IUppload {
   constructor(settings?: IUpploadSettings) {
     this.settings = {};
     this.updateSettings(settings || {});
-    const div = document.createElement("div");
+    this.container = document.createElement("div");
     this.renderContainer();
-    div.classList.add("uppload-container");
+    this.container.classList.add("uppload-container");
     const body = document.body;
     if (body) {
-      body.appendChild(div);
+      body.appendChild(this.container);
     }
-    this.container = div;
     this.focusTrap = createFocusTrap(this.container, {
       initialFocus: () => this.container.querySelector("button"),
     } as Options);


### PR DESCRIPTION
The renderContent()-Method (line 65) uses `this.container`. At this point this variable is null, because its initialization is executed after it is added to the body.