### PR TITLE
 🔧 Fixing multiple upload files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uppload",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Uppload is a JavaScript widget for better file uploading on the web.",
   "keywords": [
     "uppload",


### PR DESCRIPTION
When you drag and drop multiple images it was only uploading one image or it was only handling the first image no matter what so now should be good to upload multiple images one by one to the server 

Also, @divan mentioned this in this issue #469 

Thanks for this amazing package  @AnandChowdhary 

