### PR TITLE
Added Random string in navigation for Unique ID's

### DIFF
--- a/src/uppload.ts
+++ b/src/uppload.ts
@@ -328,6 +328,7 @@ export class Uppload implements IUppload {
    * @param sidebar - Whether this is an input radio (for sidebar) or buttons (for home)
    */
   private getNavbar(sidebar = false) {
+    const uId = (Math.random() + 1).toString(36).substring(7);
     return `<${sidebar ? "nav" : "div"} class="uppload-services">
       ${this.services
         .filter((service) => !service.invisible)
@@ -338,12 +339,12 @@ export class Uppload implements IUppload {
             }" class="uppload-service-name">
           ${
             sidebar
-              ? `<input type="radio" id="uppload-service-radio-${service.name}" value="${service.name}" name="uppload-radio">`
+              ? `<input type="radio" id="uppload-service-radio-${uId}-${service.name}" value="${service.name}" name="uppload-radio">`
               : ""
           }
           <${
             sidebar
-              ? `label for="uppload-service-radio-${service.name}"`
+              ? `label for="uppload-service-radio-${uId}-${service.name}"`
               : "button"
           } data-uppload-service="${service.name}">
             ${


### PR DESCRIPTION
The ID's are suppose to be unique in the DOM and when multiple instances are created the nav selection won't work because of duplicate ID's on the nag. Adding Unique string in the id will solve the issue.