### PR TITLE
fix: should not compress image if `compressionFromMimes` is `undefined`

### DIFF
--- a/src/uppload.ts
+++ b/src/uppload.ts
@@ -626,7 +626,7 @@ export class Uppload implements IUppload {
 
   compress(file: Blob) {
     if (
-      this.settings.compressionFromMimes &&
+      !this.settings.compressionFromMimes ||
       this.settings.compressionFromMimes.indexOf(file.type) === -1
     )
       return new Promise<Blob>((resolve) => resolve(file));


### PR DESCRIPTION
fix #887 